### PR TITLE
fix: small typing error in WebPlaybackState context

### DIFF
--- a/src/lib/types/spotify.d.ts
+++ b/src/lib/types/spotify.d.ts
@@ -80,7 +80,7 @@ interface WebPlaybackState {
   bitrate: number;
   context: {
     metadata: Record<string, unknown>;
-    uri: null;
+    uri: null | string;
   };
   disallows: {
     resuming: boolean;


### PR DESCRIPTION
First of all  thanks for the great library :rocket: . Incredible how thoughtful it is designed.
Took me some time to understand it well enough and get my wanted level of customization, but now allowed me to build stuff I could definitely not do without it :+1: 

Concerning the PR, it's just a minimal typing fix. The changed property can be either null or a string like `spotify:playlist:playlist_id`